### PR TITLE
Fix board cell width on Safari browser

### DIFF
--- a/src/lib/components/BoardCell.svelte
+++ b/src/lib/components/BoardCell.svelte
@@ -12,7 +12,7 @@
 </script>
 
 <div
-  class="flex grow items-center justify-center overflow-hidden outline-none {!$winner &&
+  class="flex w-full grow items-center justify-center overflow-hidden outline-none {!$winner &&
   board.isValidColumn(column)
     ? 'cursor-pointer'
     : 'cursor-not-allowed'}"


### PR DESCRIPTION
Board cells previously had no width in Safari causing the empty and filled markers to be invisible.